### PR TITLE
Allow ceph-mon systemd overrides to be specified

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,3 +110,13 @@ ceph_mon_docker_extra_env: -e CLUSTER={{ cluster }} -e FSID={{ fsid }} -e MON_NA
 mon_docker_privileged: false
 mon_docker_net_host: true
 ceph_config_keys: [] # DON'T TOUCH ME
+
+###########
+# SYSTEMD #
+###########
+# ceph_mon_systemd_overrides will override the systemd settings
+# for the ceph-mon services.
+# For example,to set "PrivateDevices=false" you can specify:
+#ceph_mon_systemd_overrides:
+#  Service:
+#    PrivateDevices: False

--- a/tasks/start_monitor.yml
+++ b/tasks/start_monitor.yml
@@ -1,4 +1,22 @@
 ---
+- name: ensure systemd service override directory exists
+  file:
+    state: directory
+    path: "/etc/systemd/system/ceph-mon@.service.d/"
+  when:
+    - ceph_mon_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
+- name: add ceph-mon systemd service overrides
+  config_template:
+    src: "ceph-mon.service.d-overrides.j2"
+    dest: "/etc/systemd/system/ceph-mon@.service.d/ceph-mon-systemd-overrides.conf"
+    config_overrides: "{{ ceph_mon_systemd_overrides | default({}) }}"
+    config_type: "ini"
+  when:
+    - ceph_mon_systemd_overrides is defined
+    - ansible_service_mgr == 'systemd'
+
 - name: start the monitor service
   service:
     name: ceph-mon@{{ monitor_name }}

--- a/templates/ceph-mon.service.d-overrides.j2
+++ b/templates/ceph-mon.service.d-overrides.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+[Service]


### PR DESCRIPTION
ceph-mon can fail to start under certain circumstances (for example,
when running in a container) because the default systemd service
configuration causes namespace issues.

To work around this we can override the system service settings by
placing an overrides file in the ceph-mon@.service.d directory. This can
be generic so as to allow any potential changes required to the ceph-mon
service file.

By default the overrides file won't be set up unless the
"ceph_mon_systemd_overrides" config_template override is specified.